### PR TITLE
Fixed rare issue with duplicate times

### DIFF
--- a/src/georinex/obs3.py
+++ b/src/georinex/obs3.py
@@ -75,7 +75,7 @@ def rinexobs3(
 
     # %% allocate
     if fast:
-        times = np.unique(obstime3(fn))
+        times = obstime3(fn)
     else:
         data = xarray.Dataset({}, coords={"time": [], "sv": []})
 
@@ -194,10 +194,11 @@ def rinexobs3(
                         o = obl==j
                         if not np.any(o):
                             continue
-                            data[o,t,isv]=darr[jsv,i*3]
+                        data[np.ix_(o,t,isv)]=darr[jsv,i*3]
+
                         if useindicators:
-                            data_lli[o,t,isv]=darr[jsv,i*3+1]
-                            data_ssi[o,t,isv]=darr[jsv,i*3+2]
+                            data_lli[np.ix_(o,t,isv)]=darr[jsv,i*3+1]
+                            data_ssi[np.ix_(o,t,isv)]=darr[jsv,i*3+2]
 
             else:
                 # this time epoch is complete, assemble the data.


### PR DESCRIPTION
Occasionally when reading a Rinex v3 file with duplicate times, the indexing in the fast code would break.
This was solved by broadcasting the indices using np.ix_